### PR TITLE
Use correct case for locale files

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = {
       // Filter down the locales to only those are actually exists in the package.
       config.includeLocales = config.includeLocales
       .filter(locale => typeof locale === 'string')
-      .map(locale => locale.replace('.js', '').trim().toLowerCase())
+      .map(locale => locale.replace('.js', '').trim())
       .filter(locale => {
 
         if (!this.checkLocaleExists(locale)) {


### PR DESCRIPTION
Select2 uses locale files that have a lower and uppercase portion, e.g. `select2_locale_zh_TW`.

We're currently using Select 3.8.4 which has locale files like this: https://github.com/select2/select2/tree/95a977f674b6938af55ec5f28b7772df93786c5c

Note: I did attempt to write tests for this, but the tests I found for every other `ember-cli-shim` were trivial and/or broken, and it proved far too difficult to pull into this 13 character change :(